### PR TITLE
Fix broken link for grok patterns in documentation

### DIFF
--- a/docs/reference/scripting/grok-syntax.asciidoc
+++ b/docs/reference/scripting/grok-syntax.asciidoc
@@ -11,7 +11,7 @@ fields.
 
 [[grok-syntax]]
 ==== Grok patterns
-The {stack} ships with numerous https://github.com/elastic/elasticsearch/blob/master/libs/grok/src/main/resources/patterns/grok-patterns[predefined grok patterns] that simplify working with grok. The syntax for reusing grok patterns
+The {stack} ships with numerous https://github.com/elastic/elasticsearch/blob/master/libs/grok/src/main/resources/patterns/ecs-v1/grok-patterns[predefined grok patterns] that simplify working with grok. The syntax for reusing grok patterns
 takes one of the following forms:
 
 [%autowidth]


### PR DESCRIPTION
The current link for grok patterns does not exist anymore:

https://github.com/elastic/elasticsearch/blob/master/libs/grok/src/main/resources/patterns/grok-patterns

I have replaced it with:

https://github.com/elastic/elasticsearch/blob/master/libs/grok/src/main/resources/patterns/ecs-v1/grok-patterns

But I'm unsure if it is the right link as there is also a 'legacy' folder.